### PR TITLE
Update compilation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,15 @@ env:
 
 jobs:
   test:
-    name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
+    name: Test Rust on ${{matrix.os}}
     runs-on: ${{matrix.os}}-latest
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, nightly]
         os: [ubuntu]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.toolchain}}
+      - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       # make sure benches don't bit-rot
       - name: build benches
@@ -58,10 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install minimal nightly with clippy and rustfmt
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
       - name: Clippy
         uses: actions-rs/cargo@v1
@@ -74,10 +69,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install minimal nightly with clipy
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
       - name: rustfmt
         uses: actions-rs/cargo@v1

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.83"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,7 @@ impl<A: SpongeAPI, I: List> Drop for ExtraSponge<A, I> {
 }
 
 #[cfg(test)]
+/// Unit tests for the Sponge API.
 pub mod unit_tests;
 
 #[cfg(test)]

--- a/src/unit_tests/compilation/consume.stderr
+++ b/src/unit_tests/compilation/consume.stderr
@@ -2,13 +2,32 @@ error[E0277]: the trait bound `UTerm: PrivateSub<UInt<UTerm, B1>>` is not satisf
  --> src/unit_tests/compilation/consume.rs:9:9
   |
 9 |         Use<iopat![Absorb<U3>, Squeeze<U1>, Absorb<U1>], Absorb<U6>>,
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PrivateSub<UInt<UTerm, B1>>` is not implemented for `UTerm`
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PrivateSub<UInt<UTerm, B1>>` is not implemented for `UTerm`, which is required by `Cons<extra_safe::traits::Absorb<UInt<UInt<UTerm, B1>, B1>>, Cons<extra_safe::traits::Squeeze<UInt<UTerm, B1>>, Cons<extra_safe::traits::Absorb<UInt<UTerm, B1>>, Nil>>>: Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
   |
   = help: the following other types implement trait `PrivateSub<Rhs>`:
-            <UInt<Ul, B0> as PrivateSub<UInt<Ur, B0>>>
-            <UInt<Ul, B0> as PrivateSub<UInt<Ur, B1>>>
-            <UInt<Ul, B1> as PrivateSub<UInt<Ur, B0>>>
-            <UInt<Ul, B1> as PrivateSub<UInt<Ur, B1>>>
+            `UInt<Ul, B0>` implements `PrivateSub<UInt<Ur, B0>>`
+            `UInt<Ul, B0>` implements `PrivateSub<UInt<Ur, B1>>`
+            `UInt<Ul, B1>` implements `PrivateSub<UInt<Ur, B0>>`
+            `UInt<Ul, B1>` implements `PrivateSub<UInt<Ur, B1>>`
   = note: required for `UInt<UTerm, B1>` to implement `PrivateSub<UInt<UInt<UTerm, B1>, B1>>`
   = note: required for `UInt<UInt<UTerm, B1>, B1>` to implement `Sub<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>`
-  = note: required for `Cons<Absorb<UInt<UInt<UTerm, B1>, B1>>, Cons<Squeeze<UInt<UTerm, B1>>, Cons<Absorb<UInt<UTerm, B1>>, Nil>>>` to implement `Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
+  = note: required for `Cons<extra_safe::traits::Absorb<UInt<UInt<UTerm, B1>, B1>>, Cons<extra_safe::traits::Squeeze<UInt<UTerm, B1>>, Cons<extra_safe::traits::Absorb<UInt<UTerm, B1>>, Nil>>>` to implement `Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
+
+error[E0277]: the trait bound `UTerm: PrivateSub<UInt<UTerm, B1>>` is not satisfied
+  --> src/unit_tests/compilation/consume.rs:8:5
+   |
+8  | /     assert_type_eq!(
+9  | |         Use<iopat![Absorb<U3>, Squeeze<U1>, Absorb<U1>], Absorb<U6>>,
+10 | |         iopat![Squeeze<U1>, Absorb<U1>]
+11 | |     );
+   | |_____^ the trait `PrivateSub<UInt<UTerm, B1>>` is not implemented for `UTerm`, which is required by `Cons<extra_safe::traits::Absorb<UInt<UInt<UTerm, B1>, B1>>, Cons<extra_safe::traits::Squeeze<UInt<UTerm, B1>>, Cons<extra_safe::traits::Absorb<UInt<UTerm, B1>>, Nil>>>: Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
+   |
+   = help: the following other types implement trait `PrivateSub<Rhs>`:
+             `UInt<Ul, B0>` implements `PrivateSub<UInt<Ur, B0>>`
+             `UInt<Ul, B0>` implements `PrivateSub<UInt<Ur, B1>>`
+             `UInt<Ul, B1>` implements `PrivateSub<UInt<Ur, B0>>`
+             `UInt<Ul, B1>` implements `PrivateSub<UInt<Ur, B1>>`
+   = note: required for `UInt<UTerm, B1>` to implement `PrivateSub<UInt<UInt<UTerm, B1>, B1>>`
+   = note: required for `UInt<UInt<UTerm, B1>, B1>` to implement `Sub<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>`
+   = note: required for `Cons<extra_safe::traits::Absorb<UInt<UInt<UTerm, B1>, B1>>, Cons<extra_safe::traits::Squeeze<UInt<UTerm, B1>>, Cons<extra_safe::traits::Absorb<UInt<UTerm, B1>>, Nil>>>` to implement `Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
+   = note: this error originates in the macro `assert_type_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/unit_tests/compilation/consume_head.stderr
+++ b/src/unit_tests/compilation/consume_head.stderr
@@ -4,13 +4,34 @@ error[E0277]: cannot subtract `B1` from `UInt<UTerm, B0>`
 9 |         Use<iopat![Absorb<U5>, Squeeze<U0>, Absorb<U1>], Absorb<U6>>,
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `UInt<UTerm, B0> - B1`
   |
-  = help: the trait `Sub<B1>` is not implemented for `UInt<UTerm, B0>`
+  = help: the trait `Sub<B1>` is not implemented for `UInt<UTerm, B0>`, which is required by `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Cons<extra_safe::traits::Squeeze<UTerm>, Cons<extra_safe::traits::Absorb<UInt<UTerm, B1>>, Nil>>>: Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
   = help: the following other types implement trait `Sub<Rhs>`:
-            <UInt<U, B0> as Sub<B1>>
-            <UInt<U, B> as Sub<B0>>
-            <UInt<UInt<U, B>, B1> as Sub<B1>>
-            <UInt<UTerm, B1> as Sub<B1>>
-            <UInt<Ul, Bl> as Sub<Ur>>
+            `UInt<U, B0>` implements `Sub<B1>`
+            `UInt<U, B>` implements `Sub<B0>`
+            `UInt<UInt<U, B>, B1>` implements `Sub<B1>`
+            `UInt<UTerm, B1>` implements `Sub<B1>`
+            `UInt<Ul, Bl>` implements `Sub<Ur>`
   = note: required for `UInt<UInt<UTerm, B1>, B0>` to implement `PrivateSub<UInt<UInt<UTerm, B1>, B1>>`
   = note: required for `UInt<UInt<UInt<UTerm, B1>, B0>, B1>` to implement `Sub<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>`
-  = note: required for `Cons<Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Cons<Squeeze<UTerm>, Cons<Absorb<UInt<UTerm, B1>>, Nil>>>` to implement `Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
+  = note: required for `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Cons<extra_safe::traits::Squeeze<UTerm>, Cons<extra_safe::traits::Absorb<UInt<UTerm, B1>>, Nil>>>` to implement `Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
+
+error[E0277]: cannot subtract `B1` from `UInt<UTerm, B0>`
+  --> src/unit_tests/compilation/consume_head.rs:8:5
+   |
+8  | /     assert_type_eq!(
+9  | |         Use<iopat![Absorb<U5>, Squeeze<U0>, Absorb<U1>], Absorb<U6>>,
+10 | |         Nil
+11 | |     );
+   | |_____^ no implementation for `UInt<UTerm, B0> - B1`
+   |
+   = help: the trait `Sub<B1>` is not implemented for `UInt<UTerm, B0>`, which is required by `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Cons<extra_safe::traits::Squeeze<UTerm>, Cons<extra_safe::traits::Absorb<UInt<UTerm, B1>>, Nil>>>: Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
+   = help: the following other types implement trait `Sub<Rhs>`:
+             `UInt<U, B0>` implements `Sub<B1>`
+             `UInt<U, B>` implements `Sub<B0>`
+             `UInt<UInt<U, B>, B1>` implements `Sub<B1>`
+             `UInt<UTerm, B1>` implements `Sub<B1>`
+             `UInt<Ul, Bl>` implements `Sub<Ur>`
+   = note: required for `UInt<UInt<UTerm, B1>, B0>` to implement `PrivateSub<UInt<UInt<UTerm, B1>, B1>>`
+   = note: required for `UInt<UInt<UInt<UTerm, B1>, B0>, B1>` to implement `Sub<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>`
+   = note: required for `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Cons<extra_safe::traits::Squeeze<UTerm>, Cons<extra_safe::traits::Absorb<UInt<UTerm, B1>>, Nil>>>` to implement `Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>>`
+   = note: this error originates in the macro `assert_type_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/unit_tests/compilation/normalize.stderr
+++ b/src/unit_tests/compilation/normalize.stderr
@@ -5,3 +5,11 @@ error[E0277]: the trait bound `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UT
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Same<Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B0>>, Nil>>` is not implemented for `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Nil>`
   |
   = note: this error originates in the macro `assert_type_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Nil>: Same<Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B0>>, Nil>>` is not satisfied
+ --> src/unit_tests/compilation/normalize.rs:7:5
+  |
+7 |     assert_type_eq!(Norm<iopat![Absorb<U2>, Absorb<U3>]>, iopat![Absorb<U4>]);
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Same<Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B0>>, Nil>>` is not implemented for `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Nil>`
+  |
+  = note: this error originates in the macro `assert_type_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/unit_tests/compilation/normalize_complex.stderr
+++ b/src/unit_tests/compilation/normalize_complex.stderr
@@ -8,3 +8,14 @@ error[E0277]: the trait bound `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UI
    | |_____^ the trait `Same<Cons<extra_safe::traits::Absorb<UInt<UInt<UTerm, B1>, B0>>, Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>, Nil>>>` is not implemented for `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>>, Nil>`
    |
    = note: this error originates in the macro `assert_type_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>>, Nil>: Same<Cons<extra_safe::traits::Absorb<UInt<UInt<UTerm, B1>, B0>>, Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>, Nil>>>` is not satisfied
+  --> src/unit_tests/compilation/normalize_complex.rs:7:5
+   |
+7  | /     assert_type_eq!(
+8  | |         Norm<iopat![Absorb<U2>, Squeeze<U0>, Absorb<U3>, Absorb<U3>]>,
+9  | |         iopat![Absorb<U2>, Absorb<U6>]
+10 | |     );
+   | |_____^ the trait `Same<Cons<extra_safe::traits::Absorb<UInt<UInt<UTerm, B1>, B0>>, Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B1>, B0>>, Nil>>>` is not implemented for `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>>, Nil>`
+   |
+   = note: this error originates in the macro `assert_type_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/unit_tests/compilation/sponge_bad_api.stderr
+++ b/src/unit_tests/compilation/sponge_bad_api.stderr
@@ -4,13 +4,13 @@ error[E0277]: cannot subtract `B1` from `UInt<UInt<UTerm, B0>, B0>`
 89 |         extra_sponge.absorb(Array::from_core_array(five_array), &mut Vec::default());
    |                      ^^^^^^ no implementation for `UInt<UInt<UTerm, B0>, B0> - B1`
    |
-   = help: the trait `Sub<B1>` is not implemented for `UInt<UInt<UTerm, B0>, B0>`
+   = help: the trait `Sub<B1>` is not implemented for `UInt<UInt<UTerm, B0>, B0>`, which is required by `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B0>>, Cons<extra_safe::traits::Squeeze<UInt<UInt<UTerm, B1>, B1>>, Nil>>: Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>>`
    = help: the following other types implement trait `Sub<Rhs>`:
-             <UInt<U, B0> as Sub<B1>>
-             <UInt<U, B> as Sub<B0>>
-             <UInt<UInt<U, B>, B1> as Sub<B1>>
-             <UInt<UTerm, B1> as Sub<B1>>
-             <UInt<Ul, Bl> as Sub<Ur>>
+             `UInt<U, B0>` implements `Sub<B1>`
+             `UInt<U, B>` implements `Sub<B0>`
+             `UInt<UInt<U, B>, B1>` implements `Sub<B1>`
+             `UInt<UTerm, B1>` implements `Sub<B1>`
+             `UInt<Ul, Bl>` implements `Sub<Ur>`
    = note: required for `UInt<UInt<UInt<UTerm, B1>, B0>, B0>` to implement `PrivateSub<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>`
    = note: required for `UInt<UInt<UInt<UTerm, B1>, B0>, B0>` to implement `Sub<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>`
    = note: required for `Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B0>>, Cons<extra_safe::traits::Squeeze<UInt<UInt<UTerm, B1>, B1>>, Nil>>` to implement `Consume<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>>`

--- a/src/unit_tests/compilation/sponge_creation.stderr
+++ b/src/unit_tests/compilation/sponge_creation.stderr
@@ -8,7 +8,7 @@ error[E0308]: mismatched types
 83 | |             basic_sponge,
 84 | |             &mut start_acc,
 85 | |         );
-   | |_________^ expected struct `UTerm`, found struct `UInt`
+   | |_________^ expected `UTerm`, found `UInt<UTerm, B1>`
    |
-   = note: expected struct `ExtraSponge<BasicSponge, Cons<Absorb<UInt<UInt<UTerm, B1>, B0>>, Cons<Absorb<UInt<..., ...>>, ...>>>`
-              found struct `ExtraSponge<_, Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Cons<extra_safe::traits::Squeeze<UInt<UInt<UTerm, B1>, B1>>, Nil>>>`
+   = note: expected struct `ExtraSponge<BasicSponge, Cons<extra_safe::traits::Absorb<UInt<UInt<UTerm, B1>, B0>>, Cons<extra_safe::traits::Absorb<UInt<UInt<UTerm, B1>, B1>>, Cons<extra_safe::traits::Squeeze<UInt<UInt<UTerm, B1>, B1>>, Nil>>>>`
+              found struct `ExtraSponge<BasicSponge, Cons<extra_safe::traits::Absorb<UInt<UInt<UInt<UTerm, B1>, B0>, B1>>, Cons<extra_safe::traits::Squeeze<UInt<UInt<UTerm, B1>, B1>>, Nil>>>`


### PR DESCRIPTION
- Expanded error messaging and debugging suggestions in several unit test files including 'normalize_complex.stderr', 'consume_head.stderr', and 'consume.stderr' related to trait bound not being satisfied and the `Sub<Rhs>` trait not being implemented for certain types.
- Enhanced error messages in 'sponge_creation.stderr' and 'sponge_bad_api.stderr' unit tests, addressing the mismatched expected types and clarification about specific `Sub<B1>` trait implementation.
- Comments have been added to the unit tests module in the Sponge API located in 'lib.rs' for improved clarity.
- Additional test assertions in 'normalize.stderr' unit test validate the trait implementation with `Absorb<U4>` type.
